### PR TITLE
Test user registration and login

### DIFF
--- a/app/resources/users.py
+++ b/app/resources/users.py
@@ -34,7 +34,7 @@ class UserRegistration(Resource):
 				'message': 'User {} created successfully'.format(data['username']),
 				'access token': access_token,
 				'refresh token': refresh_token
-			}
+			}, 201
 		except:
 			return {
 				'message': 'Something went wrong.'

--- a/tests.py
+++ b/tests.py
@@ -30,7 +30,66 @@ class TestBase(TestCase):
         response = self.app.get('/api/v1/')
         self.assertEqual(response.status_code, 200)
         output = json.loads(response.data)
-        self.assertEqual(output, {"message": "Welcome to Book-a-meal."})
+        self.assertEqual(output, {'message': 'Welcome to Book-a-meal.'})
+
+    def test_user_registration(self):
+        """ Test user registration. """
+        self.user = {
+            "username": "sally1",
+            "email": "sally1@example.com",
+            "password": "123456"
+        }
+        response = self.app.post("/api/v1/registration", data = self.user)
+        self.assertEqual(response.status_code, 201)
+        output = json.loads(response.data)
+        self.assertIn(self.user["username"], str(response.data))
+
+    def test_registered_user(self):
+        """ Test registered user can't register again. """
+        self.user = {
+            "username": "sally1",
+            "email": "sally1@example.com",
+            "password": "123456"
+        }
+        response = self.app.post("/api/v1/registration", data = self.user)
+        self.assertEqual(response.status_code, 201)
+        result = self.app.post("/api/v1/registration", data = self.user)
+        self.assertEqual(response.status_code, 201)
+        result = json.loads(response.data)
+        self.assertTrue(result, {'message': 'User {} already exists'.format('username')})
+    
+    def test_user_login(self):
+        """ Test user can login. """
+        self.user = {
+            "username": "sally1",
+            "email": "sally1@example.com",
+            "password": "123456"
+        }
+        response = self.app.post("/api/v1/registration", data = self.user)
+        self.assertEqual(response.status_code, 201)
+        response = self.app.post("/api/v1/login", data = self.user)
+        self.assertEqual(response.status_code, 200)
+        output = json.loads(response.data)
+        self.assertTrue(output, {'message': 'Logged in as {}'.format('username')})
+
+    def test_non_registered_user_login(self):
+        """ Test non registered user can not login. """
+        self.user = {
+            "username": "sally1",
+            "email": "sally1@example.com",
+            "password": "123456"
+        }
+        response = self.app.post("/api/v1/registration", data = self.user)
+        self.assertEqual(response.status_code, 201)
+        self.unrgistered_user = {
+            "username": "sally",
+            "email": "sally@example.com",
+            "password": "123456"
+        }
+        response = self.app.post("/api/v1/login", data = self.user)
+        self.assertEqual(response.status_code, 200)
+        output = json.loads(response.data)
+        self.assertTrue(output, {'message': 'User {} doesn\'t exist'.format('username')})
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add tests to the `  ../api/v1/registration  ` and `  ../api/v1/login  ` endpoints. We check whether;

1. a user can successfully register,
2. a registered user can not register again,
3. a registered user can login,
4. and an un-registered user can not login.